### PR TITLE
i_garantieende_auswahl

### DIFF
--- a/app/src/main/java/de/projektss17/bonpix/A_OCR_Manuell.java
+++ b/app/src/main/java/de/projektss17/bonpix/A_OCR_Manuell.java
@@ -117,7 +117,7 @@ public class A_OCR_Manuell extends AppCompatActivity {
                     picker.setMinValue(1);
                     picker.setValue(2);
                     final AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setTitle("Garantielänge");
+                    builder.setTitle("Garantielänge (Jahre)");
                     builder.setView(dialogView);
                     builder.setPositiveButton("Bestätigen", new DialogInterface.OnClickListener(){
                         public void onClick(DialogInterface dialog, int index){

--- a/app/src/main/java/de/projektss17/bonpix/A_OCR_Manuell.java
+++ b/app/src/main/java/de/projektss17/bonpix/A_OCR_Manuell.java
@@ -104,14 +104,12 @@ public class A_OCR_Manuell extends AppCompatActivity {
 
         /**
          * Guarantee Listener - Triggers Dialog (NumberPicker)
-         * Is setting GuaranteeEnd and Guarantee Boolean
+         * Is setting GuaranteeEnd with FormattedDate and Guarantee Boolean
          */
         this.garantieButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if(bonGarantie==false) {
-                    bonGarantie = true;
-                    garantieButton.setColorFilter(R.color.colorPrimary);
+                if(bonGarantie == false) {
                     LayoutInflater inflater = LayoutInflater.from(context);
                     View dialogView = inflater.inflate(R.layout.box_ocr_manuell_dialog_picker, null);
                     final NumberPicker picker = (NumberPicker) dialogView.findViewById(R.id.number_picker);
@@ -133,13 +131,16 @@ public class A_OCR_Manuell extends AppCompatActivity {
                             Date newDate = calendar.getTime();
                             String dateFormatted = new SimpleDateFormat("dd-MM-yyyy").format(newDate);
                             bon.setGuaranteeEnd(dateFormatted);
+                            bonGarantie = true;
+                            garantieButton.setColorFilter(R.color.colorPrimary);
                             S.outShort(A_OCR_Manuell.this, "Garantie wurde hinzugefügt!");
                             Log.e("### GuaranteeEnd VALUE:", "" + dateFormatted);
                         }
                     });
                     builder.setNegativeButton("Abbrechen", new DialogInterface.OnClickListener(){
                         public void onClick(DialogInterface dialog, int index){
-                            // Dismiss
+                            bonGarantie = false;
+                            garantieButton.setColorFilter(Color.WHITE);
                         }
                     });
                     final AlertDialog yearPickerDialog = builder.create();

--- a/app/src/main/java/de/projektss17/bonpix/A_OCR_Manuell.java
+++ b/app/src/main/java/de/projektss17/bonpix/A_OCR_Manuell.java
@@ -31,6 +31,7 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.NumberPicker;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -38,9 +39,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Comparator;
+import java.util.Date;
 
 import de.projektss17.bonpix.daten.C_Artikel;
 import de.projektss17.bonpix.daten.C_Bon;
@@ -66,6 +69,7 @@ public class A_OCR_Manuell extends AppCompatActivity {
     private boolean bonGarantie = false;
     private C_OCR ocr;
     private C_Bon bon;
+    private A_OCR_Manuell context = this;
 
 
     @Override
@@ -98,22 +102,51 @@ public class A_OCR_Manuell extends AppCompatActivity {
         this.bon = new C_Bon("NA","", "", "", this.dateTextView.getText().toString(), "NA", false, false, null); // Erstellt einen Leeren Bon
 
 
-        // Garantie Button onClickListener
+        /**
+         * Guarantee Listener - Triggers Dialog (NumberPicker)
+         * Is setting GuaranteeEnd and Guarantee Boolean
+         */
         this.garantieButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-
                 if(bonGarantie==false) {
                     bonGarantie = true;
                     garantieButton.setColorFilter(R.color.colorPrimary);
-
-                    // PopUp Info Fenster wird geöffnet und automatisch geschlossen
-                    S.outShort(A_OCR_Manuell.this, "Garantie wurde hinzugefügt!");
-                }else{
+                    LayoutInflater inflater = LayoutInflater.from(context);
+                    View dialogView = inflater.inflate(R.layout.box_ocr_manuell_dialog_picker, null);
+                    final NumberPicker picker = (NumberPicker) dialogView.findViewById(R.id.number_picker);
+                    picker.setMaxValue(5);
+                    picker.setMinValue(1);
+                    picker.setValue(2);
+                    final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+                    builder.setTitle("Garantielänge");
+                    builder.setView(dialogView);
+                    builder.setPositiveButton("Bestätigen", new DialogInterface.OnClickListener(){
+                        public void onClick(DialogInterface dialog, int index){
+                            Date date = new Date();
+                            Calendar calendar = Calendar.getInstance();
+                            calendar.setTime(date);
+                            int yearPicked = picker.getValue();
+                            int year = Calendar.getInstance().get(Calendar.YEAR);
+                            year += yearPicked;
+                            calendar.set(Calendar.YEAR, year);
+                            Date newDate = calendar.getTime();
+                            String dateFormatted = new SimpleDateFormat("dd-MM-yyyy").format(newDate);
+                            bon.setGuaranteeEnd(dateFormatted);
+                            S.outShort(A_OCR_Manuell.this, "Garantie wurde hinzugefügt!");
+                            Log.e("### GuaranteeEnd VALUE:", "" + dateFormatted);
+                        }
+                    });
+                    builder.setNegativeButton("Abbrechen", new DialogInterface.OnClickListener(){
+                        public void onClick(DialogInterface dialog, int index){
+                            // Dismiss
+                        }
+                    });
+                    final AlertDialog yearPickerDialog = builder.create();
+                    yearPickerDialog.show();
+                } else {
                     bonGarantie = false;
                     garantieButton.setColorFilter(Color.WHITE);
-
-                    // PopUp Info Fenster wird geöffnet und automatisch geschlossen
                     S.outShort(A_OCR_Manuell.this, "Garantie wurde entfernt!");
                 }
             }

--- a/app/src/main/res/layout/box_ocr_manuell_dialog_picker.xml
+++ b/app/src/main/res/layout/box_ocr_manuell_dialog_picker.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NumberPicker xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/number_picker"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</NumberPicker>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Hauptfarben -->
-    <color name="colorPrimary">#ffc107</color>
-    <color name="colorPrimaryDark">#ff8f00</color>
-    <color name="colorAccent">#03a9f4</color>
+    <color name="colorPrimary">#607d8b</color>
+    <color name="colorPrimaryDark">#455a64</color>
+    <color name="colorAccent">#ffab40</color>
 
     <!-- Transparenz für die Floating buttons -->
     <color name="colorTransBg">#26000000</color>


### PR DESCRIPTION
_Beschreibung: Es soll über den "Garantiebutton" in der Manuell Maske ein Allerdialog angezeigt werden, indem es möglich ist eine Garantielänge auszuwählen._

AlertDialog wird über den GarantieButton oben ausgeführt. Darauf kann man mit einem NumberPicker die Länge in Jahre auswählen. Mit dem Klick auf "Bestätigen" wird die Bon Value "guaranteeEnd" gesetzt. Hierzu ist auch noch ein Log drin, wodurch man in der Console sehen kann, auf was es gesetzt wird.


_Zusatzinformationen:
Bitte ein Attribut (garantieLaenge) hinzufügen und in der Funktion saveBon beachten!_

garantieLaenge wurde nicht hinzugefügt, daher brauche ich saveBon soweit nicht beachten, meiner Meinung nach. Sollte alles passen. 
(Falls es anders gedacht war, sagt bescheid)