### PR TITLE
i_roundebitmap_fix

### DIFF
--- a/app/src/main/java/de/projektss17/bonpix/daten/C_Adapter_Bons.java
+++ b/app/src/main/java/de/projektss17/bonpix/daten/C_Adapter_Bons.java
@@ -77,10 +77,7 @@ public class C_Adapter_Bons extends RecyclerView.Adapter<C_Adapter_Bons.ViewHold
     public void onBindViewHolder(final ViewHolder holder, final int position){
         final C_Bon bon = bonsList.get(position);
 
-        Bitmap imageBitmap = S.getShopIcon(holder.res, bon.getShopName());
-        RoundedBitmapDrawable roundedBitmapDrawable = RoundedBitmapDrawableFactory.create(holder.res, imageBitmap);
-        roundedBitmapDrawable.setAntiAlias(true);
-        holder.icon.setImageDrawable(roundedBitmapDrawable);
+        holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
 
         holder.title.setText(bon.getShopName());
         holder.content.setText(S.getWeekday(holder.res, S.getWeekdayNumber(bon.getDate())) + "\n" + bon.getDate());

--- a/app/src/main/java/de/projektss17/bonpix/daten/C_Adapter_Favoriten.java
+++ b/app/src/main/java/de/projektss17/bonpix/daten/C_Adapter_Favoriten.java
@@ -75,10 +75,7 @@ public class C_Adapter_Favoriten extends RecyclerView.Adapter<C_Adapter_Favorite
     public void onBindViewHolder(final C_Adapter_Favoriten.MyViewHolder holder, final int position) {
         this.bon = bonListe.get(position);
 
-        Bitmap imageBitmap = S.getShopIcon(holder.res, bon.getShopName());
-        RoundedBitmapDrawable roundedBitmapDrawable = RoundedBitmapDrawableFactory.create(holder.res, imageBitmap);
-        roundedBitmapDrawable.setAntiAlias(true);
-        holder.icon.setImageDrawable(roundedBitmapDrawable);
+        holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
         holder.favoriteShopName.setText(bon.getShopName());
         holder.favouritePrice.setText(bon.getTotalPrice() + " €");
         holder.favoriteDate.setText(S.getWeekday(holder.res, S.getWeekdayNumber(bon.getDate())) + "\n" + bon.getDate());

--- a/app/src/main/java/de/projektss17/bonpix/daten/C_Adapter_Garantie.java
+++ b/app/src/main/java/de/projektss17/bonpix/daten/C_Adapter_Garantie.java
@@ -78,10 +78,8 @@ public class C_Adapter_Garantie extends RecyclerView.Adapter<C_Adapter_Garantie.
     public void onBindViewHolder(final C_Adapter_Garantie.MyViewHolder holder, final int position) {
 
         this.bon = bonListe.get(position);
-        Bitmap imageBitmap = S.getShopIcon(holder.res, bon.getShopName());
-        RoundedBitmapDrawable roundedBitmapDrawable = RoundedBitmapDrawableFactory.create(holder.res, imageBitmap);
-        roundedBitmapDrawable.setAntiAlias(true);
-        holder.icon.setImageDrawable(roundedBitmapDrawable);
+        
+        holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
         holder.warrantyShop.setText(bon.getShopName());
         holder.warrantyEnd.setText(holder.res.getString(R.string.a_garantie_garantie_bis) + " " + bon.getGuaranteeEnd());
 

--- a/app/src/main/java/de/projektss17/bonpix/daten/C_Laeden_Adapter.java
+++ b/app/src/main/java/de/projektss17/bonpix/daten/C_Laeden_Adapter.java
@@ -82,6 +82,8 @@ public class C_Laeden_Adapter extends RecyclerView.Adapter<C_Laeden_Adapter.MyVi
         roundedBitmapDrawable.setAntiAlias(true);
         holder.iconShop.setImageDrawable(roundedBitmapDrawable);
 
+        //holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
+
         holder.shopName.setText(shop.getName());
 
         //Bei Supported Shops darf der Editierbutton nicht erscheinen => Wird unsichtbar gemacht

--- a/app/src/main/java/de/projektss17/bonpix/daten/C_Laeden_Adapter.java
+++ b/app/src/main/java/de/projektss17/bonpix/daten/C_Laeden_Adapter.java
@@ -77,13 +77,7 @@ public class C_Laeden_Adapter extends RecyclerView.Adapter<C_Laeden_Adapter.MyVi
     public void onBindViewHolder(final C_Laeden_Adapter.MyViewHolder holder, final int position) {
         this.shop = shopList.get(position);
 
-        Bitmap imageBitmap = S.getShopIcon(holder.res, this.shop.getName());
-        RoundedBitmapDrawable roundedBitmapDrawable = RoundedBitmapDrawableFactory.create(holder.res, imageBitmap);
-        roundedBitmapDrawable.setAntiAlias(true);
-        holder.iconShop.setImageDrawable(roundedBitmapDrawable);
-
-        //holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
-
+        holder.iconShop.setImageBitmap(S.getShopIcon(holder.res, shop.getName()));
         holder.shopName.setText(shop.getName());
 
         //Bei Supported Shops darf der Editierbutton nicht erscheinen => Wird unsichtbar gemacht


### PR DESCRIPTION
Code wurde bei foglenden Adaptern geändert
- C_Adapter_Bons
- C_Adapder_Favoriten
- C_Adapter_Garantie
- C_Laeden_Adapter

folgende Zeile wurde eingefügt:
  holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));

Anmerkung:
- bei C_Laeden_Adapter konnte  folgende Zeile nicht implementiert werden
  holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
   --> die Variable "bon" wird nicht erkannt und es gibt eine Fehlermeldung
   --> habe sie daher auskommentiert und alten Code stehen lassen