### PR TITLE
i_budget_layout

### DIFF
--- a/app/src/main/res/layout/box_budget_content.xml
+++ b/app/src/main/res/layout/box_budget_content.xml
@@ -7,7 +7,7 @@
         android:layout_width="match_parent"
         android:layout_height="265dp">
         <android.support.v7.widget.CardView
-            android:layout_width="380dp"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:elevation="15dp"
             android:layout_marginTop="8dp"


### PR DESCRIPTION
Den Rand der beim Budget hinzufügen auf der rechten Seite beim Emulator war ist weg.