### PR TITLE
i_bug_21

### DIFF
--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Bons.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Bons.java
@@ -23,6 +23,7 @@ public class C_Adapter_Bons extends RecyclerView.Adapter<C_Adapter_Bons.ViewHold
     private List<C_Bon> bonsList;
     private int row_index = -1;
     private Intent intent;
+    private String ladenName;
 
     /**
      * Standard Constructor
@@ -69,8 +70,15 @@ public class C_Adapter_Bons extends RecyclerView.Adapter<C_Adapter_Bons.ViewHold
     public void onBindViewHolder(final ViewHolder holder, final int position){
 
         final C_Bon bon = bonsList.get(position);
+
+        if(bon.getShopName().length()>10){
+            ladenName = bon.getShopName().substring(0,8) + "..";
+        } else{
+            ladenName = bon.getShopName();
+        }
+
         holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
-        holder.title.setText(bon.getShopName());
+        holder.title.setText(ladenName);
         holder.content.setText(S.getWeekday(holder.res, S.getWeekdayNumber(bon.getDate())) + "\n" + bon.getDate());
         holder.price.setText(String.format("%s €", bon.getTotalPrice().replace(".", ",")));
 

--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Bons.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Bons.java
@@ -71,11 +71,7 @@ public class C_Adapter_Bons extends RecyclerView.Adapter<C_Adapter_Bons.ViewHold
 
         final C_Bon bon = bonsList.get(position);
 
-        if(bon.getShopName().length()>10){
-            ladenName = bon.getShopName().substring(0,8) + "..";
-        } else{
-            ladenName = bon.getShopName();
-        }
+        ladenName = bon.getShopName().length()>10 ? bon.getShopName().substring(0,8) + ".." : bon.getShopName();
 
         holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
         holder.title.setText(ladenName);

--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Favoriten.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Favoriten.java
@@ -70,11 +70,8 @@ public class C_Adapter_Favoriten extends RecyclerView.Adapter<C_Adapter_Favorite
 
         this.bon = bonListe.get(position);
 
-        if(bon.getShopName().length()>10){
-            ladenName = bon.getShopName().substring(0,8) + "..";
-        } else{
-            ladenName = bon.getShopName();
-        }
+        ladenName = bon.getShopName().length()>10 ? bon.getShopName().substring(0,8) + ".." : bon.getShopName();
+
         holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
         holder.favoriteShopName.setText(ladenName);
         holder.favouritePrice.setText(bon.getTotalPrice() + " €");

--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Favoriten.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Favoriten.java
@@ -21,6 +21,7 @@ public class C_Adapter_Favoriten extends RecyclerView.Adapter<C_Adapter_Favorite
 
     private List<C_Bon> bonListe;
     private C_Bon bon;
+    private String ladenName;
 
     /**
      * Standard Constructor
@@ -68,8 +69,14 @@ public class C_Adapter_Favoriten extends RecyclerView.Adapter<C_Adapter_Favorite
     public void onBindViewHolder(final C_Adapter_Favoriten.MyViewHolder holder, final int position) {
 
         this.bon = bonListe.get(position);
+
+        if(bon.getShopName().length()>10){
+            ladenName = bon.getShopName().substring(0,8) + "..";
+        } else{
+            ladenName = bon.getShopName();
+        }
         holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
-        holder.favoriteShopName.setText(bon.getShopName());
+        holder.favoriteShopName.setText(ladenName);
         holder.favouritePrice.setText(bon.getTotalPrice() + " €");
         holder.favoriteDate.setText(S.getWeekday(holder.res, S.getWeekdayNumber(bon.getDate())) + "\n" + bon.getDate());
         holder.deleteBtn.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Garantie.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Garantie.java
@@ -70,11 +70,7 @@ public class C_Adapter_Garantie extends RecyclerView.Adapter<C_Adapter_Garantie.
 
         this.bon = bonListe.get(position);
 
-        if(bon.getShopName().length()>10){
-            ladenName = bon.getShopName().substring(0,8) + "..";
-        } else{
-            ladenName = bon.getShopName();
-        }
+        ladenName = bon.getShopName().length()>10 ? bon.getShopName().substring(0,8) + ".." : bon.getShopName();
 
         holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
         holder.warrantyShop.setText(ladenName);

--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Garantie.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Garantie.java
@@ -21,6 +21,7 @@ public class C_Adapter_Garantie extends RecyclerView.Adapter<C_Adapter_Garantie.
 
     private List<C_Bon> bonListe;
     private C_Bon bon;
+    private String ladenName;
 
     /**
      * Standard Constructor
@@ -68,8 +69,15 @@ public class C_Adapter_Garantie extends RecyclerView.Adapter<C_Adapter_Garantie.
     public void onBindViewHolder(final C_Adapter_Garantie.MyViewHolder holder, final int position) {
 
         this.bon = bonListe.get(position);
+
+        if(bon.getShopName().length()>10){
+            ladenName = bon.getShopName().substring(0,8) + "..";
+        } else{
+            ladenName = bon.getShopName();
+        }
+
         holder.icon.setImageBitmap(S.getShopIcon(holder.res, bon.getShopName()));
-        holder.warrantyShop.setText(bon.getShopName());
+        holder.warrantyShop.setText(ladenName);
         holder.warrantyEnd.setText(holder.res.getString(R.string.a_garantie_garantie_bis) + " " + bon.getGuaranteeEnd());
         holder.warrantyPrice.setText(bon.getTotalPrice() + holder.res.getString(R.string.waehrung));
         holder.deleteBtn.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Home.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Home.java
@@ -301,11 +301,7 @@ public class C_Adapter_Home extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
         String ladenName;
 
-        if(bon.getShopName().length()>10){
-            ladenName = bon.getShopName().substring(0,8) + "..";
-        } else{
-            ladenName = bon.getShopName();
-        }
+        ladenName = bon.getShopName().length()>10 ? bon.getShopName().substring(0,8) + ".." : bon.getShopName();
 
         shopName.setText(ladenName);
         date.setText(bon.getDate());

--- a/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Home.java
+++ b/app/src/main/java/de/projektss17/bonpix/adapter/C_Adapter_Home.java
@@ -299,7 +299,15 @@ public class C_Adapter_Home extends RecyclerView.Adapter<RecyclerView.ViewHolder
         final ImageView shopIcon = (ImageView)rowView.findViewById(R.id.bons_shop_image);
         final ImageView favIcon = proofFavorite(bon,(ImageView)rowView.findViewById(R.id.bons_favorite_icon));
 
-        shopName.setText(bon.getShopName());
+        String ladenName;
+
+        if(bon.getShopName().length()>10){
+            ladenName = bon.getShopName().substring(0,8) + "..";
+        } else{
+            ladenName = bon.getShopName();
+        }
+
+        shopName.setText(ladenName);
         date.setText(bon.getDate());
         price.setText(bon.getTotalPrice() + " " + curreny);
         shopIcon.setImageBitmap(S.getShopIcon(context.getResources(), bon.getShopName()));

--- a/app/src/main/res/layout/box_favoriten_view.xml
+++ b/app/src/main/res/layout/box_favoriten_view.xml
@@ -50,7 +50,7 @@
         android:gravity="center_vertical"
         android:text="@string/a_favoriten_preis"
         android:maxLength="10"
-        android:textSize="24sp"/>
+        android:textSize="18sp"/>
 
 
     <ImageView

--- a/app/src/main/res/layout/box_garantie_view.xml
+++ b/app/src/main/res/layout/box_garantie_view.xml
@@ -50,7 +50,7 @@
         android:gravity="center_vertical"
         android:text="Preis"
         android:maxLength="10"
-        android:textSize="24sp"/>
+        android:textSize="18sp"/>
 
 
     <ImageView


### PR DESCRIPTION
Ladenlängebug behoben:

- Hometab
- Bonstab
- Favoriten
- Garantie

Alle Lädennamen, die länger als 10 Zeichen werden folgendermaßen angezeigt:
 - <8 Zeichen des Ladennamen> + ".." 
 - Beispiel Media Markt: Media Ma.. 
 
 Zu dem wurde die Größe der Preisanzeige bei der Favoriten Liste und Garantie Liste angepasst